### PR TITLE
Replace Filament info widget with custom DateTime widget

- Created DateTimeWidget showing time in 12-hour format (bold)
- Added day and date display underneath in normal text
- Replaced FilamentInfoWidget in admin panel configuration
- Custom widget shows current time, day, and date in centered layout
- Responsive design with dark mode support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,17 @@ composer dev  # Runs PHP server, queue listener, log viewer, and Vite concurrent
 ./vendor/bin/pint --test  # Check style without fixing (used in CI)
 ```
 
+### Git Workflow for Upstream Changes
+```bash
+# IMPORTANT: Always use these commands when committing changes upstream
+./scripts/git-start.sh [branch-name]    # Start a new feature branch
+# ... make your changes and commits ...
+./scripts/git-finish.sh [commit-msg]    # Format, commit, PR, and merge
+
+# These scripts ensure proper branching workflow and auto-formatting
+# NEVER commit directly to main - always use feature branches
+```
+
 ## Development Commands
 
 ### Environment Management

--- a/app/Filament/Widgets/DateTimeWidget.php
+++ b/app/Filament/Widgets/DateTimeWidget.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use Filament\Widgets\Widget;
+
+class DateTimeWidget extends Widget
+{
+    protected static string $view = 'filament.widgets.date-time-widget';
+
+    protected int|string|array $columnSpan = 'full';
+
+    protected static ?int $sort = 3;
+
+    public function getViewData(): array
+    {
+        $now = now();
+
+        return [
+            'time' => $now->format('g:i A'), // 12-hour format with AM/PM
+            'day' => $now->format('l'), // Full day name (Monday, Tuesday, etc.)
+            'date' => $now->format('F j, Y'), // Month Day, Year (January 15, 2024)
+        ];
+    }
+}

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -49,7 +49,7 @@ class AdminPanelProvider extends PanelProvider
             ->widgets([
                 Widgets\AccountWidget::class,
                 \App\Filament\Widgets\AnalyticsOverviewWidget::class,
-                Widgets\FilamentInfoWidget::class,
+                \App\Filament\Widgets\DateTimeWidget::class,
             ])
             ->middleware([
                 EncryptCookies::class,

--- a/resources/views/filament/widgets/date-time-widget.blade.php
+++ b/resources/views/filament/widgets/date-time-widget.blade.php
@@ -1,0 +1,14 @@
+<x-filament-widgets::widget>
+    <x-filament::section>
+        <div class="flex items-center justify-center p-4">
+            <div class="text-center">
+                <div class="text-2xl font-bold text-gray-900 dark:text-white mb-1">
+                    {{ $time }}
+                </div>
+                <div class="text-sm text-gray-600 dark:text-gray-400">
+                    {{ $day }}, {{ $date }}
+                </div>
+            </div>
+        </div>
+    </x-filament::section>
+</x-filament-widgets::widget>


### PR DESCRIPTION
## Summary
Replace Filament info widget with custom DateTime widget

- Created DateTimeWidget showing time in 12-hour format (bold)
- Added day and date display underneath in normal text
- Replaced FilamentInfoWidget in admin panel configuration
- Custom widget shows current time, day, and date in centered layout
- Responsive design with dark mode support

## Changes
- CLAUDE.md
- app/Filament/Widgets/DateTimeWidget.php
- app/Providers/Filament/AdminPanelProvider.php
- resources/views/filament/widgets/date-time-widget.blade.php

🤖 Generated with [Claude Code](https://claude.ai/code)